### PR TITLE
Fixed issue with search/download and muliple attributes

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -163,7 +163,7 @@ method.getResults = function (queryObj, callback) {
 
                 var subDirs = getSubDirs(locDB.subDir, record);
 
-                recordsFound[sys_id] = {
+                recordsFound[sys_id+fieldName] = {
                     recordName: recordName,
                     recordData: recordData,
                     table: locDB.table,
@@ -175,7 +175,7 @@ method.getResults = function (queryObj, callback) {
                 var additionalProps = ['sys_id', 'sys_updated_on', 'sys_updated_by'];
                 for (var i = 0; i < additionalProps.length; i++) {
                     var key = additionalProps[i];
-                    recordsFound[sys_id][key] = record[key];
+                    recordsFound[sys_id+fieldName][key] = record[key];
                 }
 
             }


### PR DESCRIPTION
Fixed issue with record with multiple attributes not creating multiple files when mapped.

recordsFound was indexed by the sys_id.  When multiple attributes are
mapped from a single record, one one file would be created.  Changed the
index to include the fieldName so that there will be an unique entry for
each field to be mapped.