### PR TITLE
Authentication - .netrc credential support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,30 @@ Example app.config.json (see also the included app.config.json file):
     }
 ```
 
+#### .netrc Auth Example
 
+This example shows how to use the .netrc file for credentials.
+
+Example app.config.json:
+
+```javascript
+    {
+        "roots": {
+            "/Users/joe.developer/instance/records": {
+                "host": "some-instance.service-now.com"
+            }
+        },
+        "useNetrcAuth": true
+    }
+```
+
+Example ~/.netrc file:
+
+```
+machine some-instance.service-now.com
+login admin
+password hgdf723jdt72u28
+```
 
 ## Advanced settings
 
@@ -278,6 +301,7 @@ preLoad | Bool: true / false | false | Creates local files that can be specified
 ignoreList | Array of matches | `/[\/\\]\./` | Define what files are **not** tracked for changes. Defaults to ignore hidden files on any directory level (eg `.sync_data`). Usage details can be found on the [chokidar readme](https://github.com/paulmillr/chokidar#path-filtering).
 ensureUniqueNames | Bool: true / false | false | If set to true then files will be post-fixed with the record sys_id to ensure all saved files have unique names. This supports records that have the same name on the same table. By default this is false to encourage more useful record names on the instance.
 proxy | Object | not set | Required if stuck behind a proxy. <br />Eg. `"proxy": { `<br />`"host": "host.com",`<br />`"port": "3860"`<br />` }`
+useNetrcAuth | Bool: true / false | false | If set to true, authentication information information will be retrieved from your ~/.netrc file. This provides a simple mechanism to keep credentials separate from your project configuration.<br />The .netrc file is a standard mechanism used by many command line utilites (e.g. curl, ftp, httpie, etc.) to store credentials in a controlled way.
 
 
 #### Root specific options

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,7 @@ require('colors');
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
+var netrcConfig = require('./netrc_credentials');
 
 // non documented function. Worry about that some other day. It won't go away soon because nodejs relies on it!
 var extend = require('util')._extend;
@@ -76,6 +77,9 @@ function getConfig() {
     var config = require(config_file);
     config.debug = config.debug || false;
 
+    // Allow using the netrc auth instead of hard coded credentials (https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html)
+    config.useNetrcAuth = config.useNetrcAuth || false;
+
     assert.object(config.roots, 'roots');
 
     var roots = Object.keys(config.roots);
@@ -89,9 +93,25 @@ function getConfig() {
         validateRootFolder(root);
         var host = config.roots[root];
         assert.ok(host.host, 'Invalid root config. host missing.');
-        if (!host.auth) {
+
+        if (config.useNetrcAuth) {
+            assert.ok(netrcConfig.hasCredentials(host.host), 'Host is missing the .netrc credentials');
+
+            // Fetch the credentials from the .netrc file
+            var creds = netrcConfig.getCredentials(host.host);
+            host.user = creds.user;
+            host.pass = creds.pass;
+
+            // Encode the credentials the same way we always do, but don't persist them
             config.roots[root] = encodeCredentials(host);
-            save = true;
+
+            // We don't want to save, because the config will dynamically come from the .netrc file
+            save = false;
+        } else {
+            if (!host.auth) {
+                config.roots[root] = encodeCredentials(host);
+                save = true;
+            }
         }
     });
 

--- a/lib/netrc_credentials.js
+++ b/lib/netrc_credentials.js
@@ -2,8 +2,6 @@ var netrc = require('netrc');
 var netrcConfig = netrc();
 
 function getCredentials(hostname) {
-    console.log("getCredentials: [" + hostname + "]");
-
     var settings = netrcConfig[hostname] || {};
 
     return {

--- a/lib/netrc_credentials.js
+++ b/lib/netrc_credentials.js
@@ -1,0 +1,23 @@
+var netrc = require('netrc');
+var netrcConfig = netrc();
+
+function getCredentials(hostname) {
+    console.log("getCredentials: [" + hostname + "]");
+
+    var settings = netrcConfig[hostname] || {};
+
+    return {
+        user: settings['login'],
+        pass: settings['password']
+    };
+}
+
+function hasCredentials(hostname) {
+    var credentials = getCredentials(hostname);
+    return credentials.user != null && credentials.pass != null;
+}
+
+module.exports = {
+    getCredentials: getCredentials,
+    hasCredentials: hasCredentials
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "glob": "^6.0.0",
     "minimist": "^1.1.1",
     "moment": "^2.10.2",
+    "netrc": "^0.1.4",
     "node-notifier": "^4.3.1",
     "osx-notifier": "^0.2.1",
     "@mishguru/restler": "https://github.com/mishguruorg/restler/tarball/master",


### PR DESCRIPTION
Hello. I've just started using this project over my hand-rolled version, and I'm very impressed!

However, I have a few enhancements I would like to discuss and validate that they are wanted by people other than just me before I continue any further.

The first one is the removal of credentials from the configuration file. I believe this would be a common requirement, and also a common security concern (I've even seen people make their credentials public in pull requests on this project). Additionally, it prevents someone from setting up and sharing a configuration (e.g. with a team).

This pull request has implemented a simple, standard mechanism for pulling the credentials from the users ~/.netrc file - a practice shared by many utilities (e.g. curl, ftp, httpie, etc.). The change is backward compatible and allows you to opt-in with a setting in your config file.

I've provided preliminary documentation, with an example, and done some simple testing on Mac, but I'm confident it would work equally well on Linux. 

What still needs to be done:

- Checking Windows support (I don't currently have access to a windows PC, but I could get it)
- Checking integration with the 'export/save as' functionality. I've only implemented and tested the standard authentication process.
- More complete documentation and testing.

Anyway, I just thought I would start the process to get comments/guidance on how to proceed.

Thanks for your time...
